### PR TITLE
add rxvt-unicode-256color TERM info

### DIFF
--- a/dircolors.ansi-dark
+++ b/dircolors.ansi-dark
@@ -80,6 +80,7 @@ TERM rxvt-cygwin
 TERM rxvt-cygwin-native
 TERM rxvt-unicode
 TERM rxvt-unicode256
+TERM rxvt-unicode-256color
 TERM screen
 TERM screen-256color
 TERM screen-256color-bce

--- a/dircolors.ansi-light
+++ b/dircolors.ansi-light
@@ -80,6 +80,7 @@ TERM rxvt-cygwin
 TERM rxvt-cygwin-native
 TERM rxvt-unicode
 TERM rxvt-unicode256
+TERM rxvt-unicode-256color
 TERM screen
 TERM screen-256color
 TERM screen-256color-bce

--- a/dircolors.ansi-universal
+++ b/dircolors.ansi-universal
@@ -79,6 +79,7 @@ TERM rxvt-cygwin
 TERM rxvt-cygwin-native
 TERM rxvt-unicode
 TERM rxvt-unicode256
+TERM rxvt-unicode-256color
 TERM screen
 TERM screen-256color
 TERM screen-256color-bce


### PR DESCRIPTION
Required this additions to work correctly with rxvt unicode with 256 color on my gentoo setup.

Note that 256dark had that entry already.
