### PR TITLE
add divx to the list of video formats

### DIFF
--- a/dircolors.256dark
+++ b/dircolors.256dark
@@ -249,6 +249,7 @@ EXEC 01;38;5;64
 .flv    01;38;5;166
 .gl     01;38;5;166
 .m2ts   01;38;5;166
+.divx   01;38;5;166
 # http://wiki.xiph.org/index.php/MIME_Types_and_File_Extensions
 .axv 01;38;5;166
 .anx 01;38;5;166


### PR DESCRIPTION
So divx is highlighted as a video file. I use 256dark, so that's the only theme I touched. I can add divx to other themes if you want.
