### PR TITLE
Fixed Ubuntu green highlight background for 777 directories

### DIFF
--- a/dircolors.ansi-dark
+++ b/dircolors.ansi-dark
@@ -146,6 +146,8 @@ NORMAL 00
 FILE 00
 # directory
 DIR 34
+# 777 directory
+OTHER_WRITABLE 34;40
 # symbolic link
 LINK 35
 


### PR DESCRIPTION
On Ubuntu, terminal shows a green highlight background for 777 directories.

About: http://ubuntuforums.org/showthread.php?t=821721

This is how I fixed it.
