### PR TITLE
Add additional screen variants

### DIFF
--- a/dircolors.256dark
+++ b/dircolors.256dark
@@ -48,6 +48,10 @@ TERM rxvt-unicode
 TERM rxvt-unicode256
 TERM rxvt-unicode-256color
 TERM screen
+TERM screen-16color
+TERM screen-16color-bce
+TERM screen-16color-s
+TERM screen-16color-bce-s
 TERM screen-256color
 TERM screen-256color-bce
 TERM screen-256color-s

--- a/dircolors.ansi-dark
+++ b/dircolors.ansi-dark
@@ -85,9 +85,14 @@ TERM rxvt-unicode
 TERM rxvt-unicode256
 TERM rxvt-unicode-256color
 TERM screen
+TERM screen-16color
+TERM screen-16color-bce
+TERM screen-16color-s
+TERM screen-16color-bce-s
 TERM screen-256color
 TERM screen-256color-bce
 TERM screen-256color-s
+TERM screen-256color-bce-s
 TERM screen-bce
 TERM screen-w
 TERM screen.linux

--- a/dircolors.ansi-light
+++ b/dircolors.ansi-light
@@ -85,9 +85,14 @@ TERM rxvt-unicode
 TERM rxvt-unicode256
 TERM rxvt-unicode-256color
 TERM screen
+TERM screen-16color
+TERM screen-16color-bce
+TERM screen-16color-s
+TERM screen-16color-bce-s
 TERM screen-256color
 TERM screen-256color-bce
 TERM screen-256color-s
+TERM screen-256color-bce-s
 TERM screen-bce
 TERM screen-w
 TERM screen.linux

--- a/dircolors.ansi-universal
+++ b/dircolors.ansi-universal
@@ -84,9 +84,14 @@ TERM rxvt-unicode
 TERM rxvt-unicode256
 TERM rxvt-unicode-256color
 TERM screen
+TERM screen-16color
+TERM screen-16color-bce
+TERM screen-16color-s
+TERM screen-16color-bce-s
 TERM screen-256color
 TERM screen-256color-bce
 TERM screen-256color-s
+TERM screen-256color-bce-s
 TERM screen-bce
 TERM screen-w
 TERM screen.linux


### PR DESCRIPTION
This patch adds support for the following terminal variants in all four
color schemes:

  screen-16color
  screen-16color-bce
  screen-16color-s
  screen-16color-bce-s
  screen-256color-bce-s

Adding these allows this theme to be used with terminals that require the xterm-16color terminal type to be specified. (This includes my personal tmux and mobaXterm setup.)
