### PR TITLE
Add .MOV file extension

### DIFF
--- a/dircolors.256dark
+++ b/dircolors.256dark
@@ -256,6 +256,7 @@ EXEC 00;38;5;64
 
 # Video formats (as audio + bold)
 .mov    00;38;5;166
+.MOV    00;38;5;166
 .mpg    00;38;5;166
 .mpeg   00;38;5;166
 .m2v    00;38;5;166

--- a/dircolors.ansi-dark
+++ b/dircolors.ansi-dark
@@ -320,6 +320,7 @@ EXEC 01;31  # Unix
 .m4v 33
 .mkv 33
 .mov 33
+.MOV 33
 .mp4 33
 .mp4v 33
 .mpeg 33

--- a/dircolors.ansi-light
+++ b/dircolors.ansi-light
@@ -318,6 +318,7 @@ EXEC 01;31  # Unix
 .m4v 33
 .mkv 33
 .mov 33
+.MOV 33
 .mp4 33
 .mp4v 33
 .mpeg 33

--- a/dircolors.ansi-universal
+++ b/dircolors.ansi-universal
@@ -317,6 +317,7 @@ EXEC 01;31  # Unix
 .m4v 33
 .mkv 33
 .mov 33
+.MOV 33
 .mp4 33
 .mp4v 33
 .mpeg 33


### PR DESCRIPTION
This is just like #49.

This is somewhat annoying, but like '.jpg' and '.JPG', sometimes '.mov' files are saved as '.MOV'.

iPhones save videos using a '.MOV' file extension, so chances are that a good number of developers will be seeing this.
