### PR TITLE
Add Dockerfile to "Files of special interest"

### DIFF
--- a/dircolors.256dark
+++ b/dircolors.256dark
@@ -211,6 +211,7 @@ EXEC 00;38;5;64
 .cpp             00;38;5;245
 .cc              00;38;5;245
 .sqlite          00;38;5;245
+*Dockerfile      00;38;5;245
 
 # "unimportant" files as logs and backups (base01)
 .log        00;38;5;240


### PR DESCRIPTION
In the same spirit as Makefiles and Rakefiles, Dockerfiles are "special
interest" files. Added support to color these files in the same style.

I personally use the 256dark variant. I checked in the ansi-* variants, but it didn't look like there was a corresponding category for special interest files. As such, I didn't modify them. If they should be updated too, let me know.