### PR TITLE
README.md mentions Ubuntu installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ To activate the theme for all future shell sessions, copy or link that file to
 `~/.dir_colors`, and include the above command in your `~/.profile` (for bash)
 or `~/.zshrc` (for zsh).
 
+For Ubuntu 14.04 it is sufficient to copy or link database file to `~/.dircolors`.
+Statement in `~/.bashrc` will take about triggering eval command.
+
 ### Additional Instructions for 256-color Solarized Themes, e.g. "256dark"
 
 For the 256-color Solarized dircolors themes, such as "256dark", you need a 256-color

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ To activate the theme for all future shell sessions, copy or link that file to
 or `~/.zshrc` (for zsh).
 
 For Ubuntu 14.04 it is sufficient to copy or link database file to `~/.dircolors`.
-Statement in `~/.bashrc` will take about triggering eval command.
+Statement in `~/.bashrc` will take care about triggering eval command.
 
 ### Additional Instructions for 256-color Solarized Themes, e.g. "256dark"
 


### PR DESCRIPTION
Looks like for Ubuntu 14.04 it's enough to link database file to `~/.dircolors` as `~/.bashrc` already has statements which execute right `eval` command.