### PR TITLE
Ship an explicit makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SHELL = /bin/sh
+
+all: 256 ansi
+
+clean:
+	rm dircolors.{256dark,ansi-dark,ansi-light,ansi-universal}
+
+dircolors.256dark:
+	curl -OJ https://raw.githubusercontent.com/seebi/dircolors-solarized/master/dircolors.256dark
+
+dircolors.ansi-dark:
+	curl -OJ https://raw.githubusercontent.com/seebi/dircolors-solarized/master/dircolors.ansi-dark
+
+dircolors.ansi-light:
+	curl -OJ https://raw.githubusercontent.com/seebi/dircolors-solarized/master/dircolors.ansi-light
+
+dircolors.ansi-universal:
+	curl -OJ https://raw.githubusercontent.com/seebi/dircolors-solarized/master/dircolors.ansi-universal
+
+256: dircolors.256dark
+
+ansi: dircolors.ansi-light dircolors.ansi-dark dircolors.ansi-universal


### PR DESCRIPTION
If this the theme is stored inside a dotfiles repository using vcsh, for example, without using git submodule or git subtree the files lose touch with version control. I suspect this is how many use this repo, particularly because of the test tarball and helpful images.

Why not use a submodule? The performance hit on cloning the repo as a submodule would be large, and it could seem counterintuitive because the codebase is somewhat static.

Rather than manually clone the repo and copy the files, it may be helpful to some to ship a simple Makefile to update the files using curl. 

Just an idea.