### PR TITLE
Added OTHER_WRITABLE to ansi-light theme

### DIFF
--- a/dircolors.ansi-light
+++ b/dircolors.ansi-light
@@ -165,6 +165,8 @@ NORMAL 00
 FILE 00
 # directory
 DIR 36
+# XX2, XX3, XX6, and XX7 directories
+OTHER_WRITABLE 34;47
 # symbolic link
 LINK 35
 


### PR DESCRIPTION
I don't know a good value for OTHER_WRITABLE which work on both dark and light, so I have not added any to ansi-universal even though it is missing.