### PR TITLE
Classify Nikon RAW files as images

### DIFF
--- a/dircolors.256dark
+++ b/dircolors.256dark
@@ -188,6 +188,8 @@ EXEC 00;38;5;64
 .eps    00;38;5;136
 .CR2    00;38;5;136
 .ico    00;38;5;136
+.nef    00;38;5;136 # Nikon RAW format
+.NEF    00;38;5;136
 
 # Files of special interest (base1)
 .tex             00;38;5;245

--- a/dircolors.ansi-dark
+++ b/dircolors.ansi-dark
@@ -308,6 +308,8 @@ EXEC 01;31  # Unix
 .xwd 33
 .xwd 33
 .yuv 33
+.nef 33 # Nikon RAW format
+.NEF 33
 
 # Audio
 .aac 33

--- a/dircolors.ansi-light
+++ b/dircolors.ansi-light
@@ -308,6 +308,8 @@ EXEC 01;31  # Unix
 .xwd 33
 .xwd 33
 .yuv 33
+.nef 33 # Nikon RAW format
+.NEF 33
 
 # Audio
 .aac 33

--- a/dircolors.ansi-universal
+++ b/dircolors.ansi-universal
@@ -305,6 +305,8 @@ EXEC 01;31  # Unix
 .xwd 33
 .xwd 33
 .yuv 33
+.NEF 33 # Nikon RAW format
+.nef 33
 
 # Audio
 .aac 33


### PR DESCRIPTION
Nikon camera can produce compressed files (.jpg) or raw files (.NEF). Classify the latter as images.