### PR TITLE
Move .pdf extension under binary document formats

### DIFF
--- a/dircolors.ansi-dark
+++ b/dircolors.ansi-dark
@@ -290,7 +290,6 @@ EXEC 01;31  # Unix
 .mng 33
 .pbm 33
 .pcx 33
-.pdf 33
 .pgm 33
 .png 33
 .PNG 33
@@ -381,6 +380,7 @@ EXEC 01;31  # Unix
 .otp 31
 .fla 31
 .psd 31
+.pdf 31
 
 # Archives, compressed
 .7z   1;35

--- a/dircolors.ansi-light
+++ b/dircolors.ansi-light
@@ -290,7 +290,6 @@ EXEC 01;31  # Unix
 .mng 33
 .pbm 33
 .pcx 33
-.pdf 33
 .pgm 33
 .png 33
 .PNG 33
@@ -381,6 +380,7 @@ EXEC 01;31  # Unix
 .otp 31
 .fla 31
 .psd 31
+.pdf 31
 
 # Archives, compressed
 .7z   1;35

--- a/dircolors.ansi-universal
+++ b/dircolors.ansi-universal
@@ -288,7 +288,6 @@ EXEC 01;31  # Unix
 .mng 33
 .pbm 33
 .pcx 33
-.pdf 33
 .pgm 33
 .png 33
 .PNG 33
@@ -379,6 +378,7 @@ EXEC 01;31  # Unix
 .otp 31
 .fla 31
 .psd 31
+.pdf 31
 
 # Archives, compressed
 .7z   1;35


### PR DESCRIPTION
Only a proposal, feel free to disagree. To me, `.pdf` makes more sense under "binary document formats" since they usually represent textual documents, even though they are not intended to be editable.