### PR TITLE
dircolors: add `linux-16color` terminal

### DIFF
--- a/dircolors.256dark
+++ b/dircolors.256dark
@@ -38,6 +38,7 @@ TERM konsole
 TERM konsole-256color
 TERM kterm
 TERM linux
+TERM linux-16color
 TERM linux-c
 TERM mach-color
 TERM mlterm

--- a/dircolors.256dark.no-bold
+++ b/dircolors.256dark.no-bold
@@ -38,6 +38,7 @@ TERM konsole
 TERM konsole-256color
 TERM kterm
 TERM linux
+TERM linux-16color
 TERM linux-c
 TERM mach-color
 TERM mlterm

--- a/dircolors.ansi-dark
+++ b/dircolors.ansi-dark
@@ -75,6 +75,7 @@ TERM konsole
 TERM konsole-256color
 TERM kterm
 TERM linux
+TERM linux-16color
 TERM linux-c
 TERM mach-color
 TERM mlterm

--- a/dircolors.ansi-light
+++ b/dircolors.ansi-light
@@ -75,6 +75,7 @@ TERM konsole
 TERM konsole-256color
 TERM kterm
 TERM linux
+TERM linux-16color
 TERM linux-c
 TERM mach-color
 TERM mlterm

--- a/dircolors.ansi-universal
+++ b/dircolors.ansi-universal
@@ -74,6 +74,7 @@ TERM konsole
 TERM konsole-256color
 TERM kterm
 TERM linux
+TERM linux-16color
 TERM linux-c
 TERM mach-color
 TERM mlterm


### PR DESCRIPTION
No reason why it should not be supported.