### PR TITLE
Add eat terminal

### DIFF
--- a/dircolors.256dark
+++ b/dircolors.256dark
@@ -28,6 +28,8 @@ TERM cygwin
 TERM dtterm
 TERM dvtm
 TERM dvtm-256color
+TERM eat-256color
+TERM eat-truecolor
 TERM eterm-color
 TERM fbterm
 TERM foot

--- a/dircolors.256dark.no-bold
+++ b/dircolors.256dark.no-bold
@@ -28,6 +28,8 @@ TERM cygwin
 TERM dtterm
 TERM dvtm
 TERM dvtm-256color
+TERM eat-256color
+TERM eat-truecolor
 TERM eterm-color
 TERM fbterm
 TERM foot

--- a/dircolors.ansi-dark
+++ b/dircolors.ansi-dark
@@ -64,6 +64,8 @@ TERM cygwin
 TERM dtterm
 TERM dvtm
 TERM dvtm-256color
+TERM eat-256color
+TERM eat-truecolor
 TERM Eterm
 TERM eterm-color
 TERM fbterm

--- a/dircolors.ansi-light
+++ b/dircolors.ansi-light
@@ -64,6 +64,8 @@ TERM cygwin
 TERM dtterm
 TERM dvtm
 TERM dvtm-256color
+TERM eat-256color
+TERM eat-truecolor
 TERM Eterm
 TERM eterm-color
 TERM fbterm

--- a/dircolors.ansi-universal
+++ b/dircolors.ansi-universal
@@ -63,6 +63,8 @@ TERM cygwin
 TERM dtterm
 TERM dvtm
 TERM dvtm-256color
+TERM eat-256color
+TERM eat-truecolor
 TERM Eterm
 TERM eterm-color
 TERM fbterm


### PR DESCRIPTION
Eat is an alternative Emacs terminal, https://codeberg.org/akib/emacs-eat.